### PR TITLE
refactor: CHI: convert tech to modifiers

### DIFF
--- a/common/history/countries/chi - china.txt
+++ b/common/history/countries/chi - china.txt
@@ -7,7 +7,6 @@
 		add_technology_researched = horde_mod
 		add_technology_researched = silk_road
 		#add_technology_researched = civilizing_mission
-		add_technology_researched = china_mod
 		
 		add_technology_researched = law_enforcement
 		
@@ -71,6 +70,21 @@
 	#	}
 		add_modifier = {
 			name = mongol_religious_tolerance
+			months = -1
+		}
+
+		add_modifier = {
+			name = china_insufficient_infrastructure
+			months = -1
+		}
+
+		add_modifier = {
+			name = china_rampant_corruption
+			months = -1
+		}
+
+		add_modifier = {
+			name = china_political_turmoil
 			months = -1
 		}
 
@@ -227,7 +241,6 @@
 		effect_starting_technology_tier_4_tech = yes
 		add_technology_researched = urban_planning
 		add_technology_researched = sericulture
-		add_technology_researched = china_mod
 		
 		add_technology_researched = law_enforcement
 		
@@ -271,6 +284,20 @@
 		add_modifier = {
 			name = inward_perfection
 			years = 150
+		}
+		add_modifier = {
+			name = china_insufficient_infrastructure
+			months = -1
+		}
+
+		add_modifier = {
+			name = china_rampant_corruption
+			months = -1
+		}
+
+		add_modifier = {
+			name = china_political_turmoil
+			months = -1
 		}
 
 	#	add_modifier = {

--- a/common/modifiers/china_modifiers.txt
+++ b/common/modifiers/china_modifiers.txt
@@ -1,0 +1,24 @@
+china_insufficient_infrastructure  = {
+	icon = gfx/interface/icons/timed_modifier_icons/modifier_coins_negative.dds
+
+	state_market_access_price_impact = -0.05
+}
+
+china_rampant_corruption = {
+	icon = gfx/interface/icons/timed_modifier_icons/modifier_documents_negative.dds
+
+	country_bureaucracy_mult = -0.25
+	state_tax_capacity_mult = -0.25
+
+	country_government_wages_mult = 0.15
+}
+
+china_political_turmoil = {
+	icon = gfx/interface/icons/timed_modifier_icons/modifier_fist_negative.dds
+
+	state_radicals_from_discrimination_mult = 0.25
+	political_movement_radicalism_mult = 0.35
+	state_turmoil_effects_mult = 0.35
+
+	interest_group_ig_rural_folk_approval_add = -3
+}

--- a/common/technology/technologies/romaioi_tech.txt
+++ b/common/technology/technologies/romaioi_tech.txt
@@ -48,37 +48,6 @@ romaioi_mod = {
 
 }
 
-china_mod = {
-	era = era_5
-	#category = none
-	texture = "gfx/interface/icons/invention_icons/urbanization.dds"
-	
-	modifier = {
-
-		#country_officers_pol_str_mult = 0.1
-
-		#Debuffs
-		country_bureaucracy_mult = -0.25
-		state_tax_capacity_mult = -0.25
-
-		country_government_wages_mult = 0.15
-
-		state_radicals_from_discrimination_mult = 0.25
-		political_movement_radicalism_mult = 0.35
-		state_turmoil_effects_mult = 0.35
-
-		interest_group_ig_rural_folk_approval_add = -3
-		state_market_access_price_impact = -0.05
-	}
-
-	can_research = no
-
-	ai_weight = {
-		value = -99 # Not meant to be researched.
-	}
-
-}
-
 italian_republic_mod = {
 	era = era_5
 	#category = none

--- a/localization/english/romaioi_misc_l_english.yml
+++ b/localization/english/romaioi_misc_l_english.yml
@@ -103,7 +103,6 @@ merchant_republic_mod2: "Merchant Republic"
 rising_sun: "Rising Sun"
 horde_mod: "Horde"
 defensive_tech_mod: "Defensive Bonus"
-china_mod: "Middle Kingdom"
 new_world_tribal: "New World Tribalism"
 
 #Companies
@@ -199,6 +198,9 @@ fur_income: "Fur Trade Income"
  modifier_magnate_oligarchy: "Magnate Oligarchy"
  modifier_slave_to_liberty: "Slave To Liberty"
 # diplomatic_plays_blocked_until_golden_liberty: "#BOLD Diplomatic plays blocked#! until #BOLD Golden Liberty#! Journal Entry is resolved"
+china_insufficient_infrastructure: "Insufficient infrastructure"
+china_rampant_corruption: "Rampant corruption"
+china_political_turmoil: "Political turmoil"
 
 city_worlds_desire_state: "City of Worlds Desire"
 great_city_state: "Magnificent City"


### PR DESCRIPTION
Makes it easier for players to be aware of the
modifiers affecting CHI, although it is not
possible to remove these modifiers just yet.