### PR TITLE
fix: add missing loc key

### DIFF
--- a/localization/english/addons/haap_l_english.yml
+++ b/localization/english/addons/haap_l_english.yml
@@ -10,6 +10,15 @@
  modifier_goods_input_horse_mult: "@horse!$horse$ input"
  modifier_goods_input_horse_mult_desc: "A bonus or penalty to the amount of @horse!$horse$ consumed"
 
+ modifier_goods_output_spices_add: "@spice!$spice$ output"
+ modifier_goods_output_spices_add_desc: "The amount of @spice!$spice$ produced by buildings"
+ modifier_goods_input_spices_add: "@spice!$spice$ input"
+ modifier_goods_input_spices_add_desc: "The amount of @spice!$spice$ consumed by buildings"
+ modifier_goods_output_spices_mult: "Building @spice!$spice$ output"
+ modifier_goods_output_spices_mult_desc: "A bonus or penalty to the amount of @spice!$spice$ produced by buildings"
+ modifier_goods_input_spices_mult: "@spice!$spice$ input"
+ modifier_goods_input_spices_mult_desc: "A bonus or penalty to the amount of @spice!$spice$ consumed"
+
  pmg_horse_ranch: "Horse Ranch"
  pm_horse_ranch: "Horse Ranch"
  pm_increased_horse_ranch: "Large-scale Horse Ranch"


### PR DESCRIPTION
This commit fixes the following types of errors:

```
[modifier_types.cpp:472]: Modifier is missing loc
 key! Modifier: goods_output_spices_add, LocKey:
 modifier_goods_output_spices_add
```

This was fixed by adding the missing loc keys
similar to how the other new resource was managed
(horse). It is unclear to me where this text
appears in game.