### PR TITLE
fix: `JAP` military formation error

### DIFF
--- a/common/history/military_formations/japan_military_formations.txt
+++ b/common/history/military_formations/japan_military_formations.txt
@@ -132,12 +132,6 @@
 
 			combat_unit = {
 				type = unit_type:combat_unit_type_line_infantry
-				state_region = s:STATE_EASTERN_HUBEI
-				count = 5
-			}
-
-			combat_unit = {
-				type = unit_type:combat_unit_type_line_infantry
 				state_region = s:STATE_SHIKOKU
 				count = 5
 			}


### PR DESCRIPTION
This commit solves the following error:

```
[jomini_script_system.cpp:262]: Script system
error!
Error: create_military_formation effect [ Japanese
Shogunate does not have state in
STATE_EASTERN_HUBEI ]
Script location: file: common/history/
military_formations/japan_military_formations.txt
line: 116
```

The fix is simply to delete the formation.