### PR TITLE
refactor: turn tech to modifier

### DIFF
--- a/common/history/countries/BYZ - Romaioi.txt
+++ b/common/history/countries/BYZ - Romaioi.txt
@@ -21,7 +21,6 @@ COUNTRIES = {
 		#add_technology_researched = modern_sewerage
 		#add_technology_researched = paved_roads
 		add_technology_researched = romaioi_mod #Custom invisible buff/debuff to make the experience more authentic feeling
-		add_technology_researched = roman_roads
 
 		#Warfare
 		
@@ -239,6 +238,10 @@ COUNTRIES = {
 		}
 		add_modifier = {
 			name = romaioi_corrupt_pronoia
+			months = -1
+		}
+		add_modifier = {
+			name = br_modifier_romaioi_roman_roads
 			months = -1
 		}
 		

--- a/common/modifiers/br_romaioi_modifiers.txt
+++ b/common/modifiers/br_romaioi_modifiers.txt
@@ -150,6 +150,17 @@ modifier_nomos_empsychos = {
 	country_prestige_mult = 0.10
 }
 
+br_modifier_romaioi_roman_roads = {
+	icon = gfx/interface/icons/timed_modifier_icons/modifier_documents_positive.dds
+
+	state_infrastructure_from_population_add = 1
+	state_infrastructure_from_population_max_add = 20
+	country_trade_route_cost_mult = -0.2
+	country_trade_route_competitiveness_mult = 0.2
+	market_land_trade_capacity_add = 100
+	state_market_access_price_impact = 0.05
+}
+
 
 #Feudal
 

--- a/common/technology/technologies/br_tech.txt
+++ b/common/technology/technologies/br_tech.txt
@@ -156,30 +156,6 @@ merchant_republic_mod2 = {
 
 }
 
-#Modern road, sewage and engineering were mostly relearning what was forgotten after the fall of the roman empire.
-roman_roads = {
-	era = era_5
-	#category = none
-	texture = "gfx/interface/icons/invention_icons/paved_roads.dds"
-	
-	modifier = {
-		#Buffs #Trade
-		state_infrastructure_from_population_add = 1
-		state_infrastructure_from_population_max_add = 20
-		country_trade_route_cost_mult = -0.2
-		country_trade_route_competitiveness_mult = 0.2
-		market_land_trade_capacity_add = 100
-		state_market_access_price_impact = 0.05
-	}
-
-	can_research = no
-
-	ai_weight = {
-		value = -99 # Not meant to be researched.
-	}
-
-}
-
 silk_road = {
 	era = era_5
 	#category = none

--- a/localization/english/br_misc_l_english.yml
+++ b/localization/english/br_misc_l_english.yml
@@ -88,7 +88,6 @@
 
  #tech
  romaioi_mod: "Romaíon Legacy" #keep for now
- roman_roads: "Romaíon Infrastructure" #keep
  tribal: "Tribal"
  andalus_mod: "Andalusian"
  silk_road: "Silk Road" #keep

--- a/localization/english/br_modifiers_l_english.yml
+++ b/localization/english/br_modifiers_l_english.yml
@@ -69,6 +69,7 @@
  japan_corporate_reforms: "Corporate Reforms"
  br_persia_persian_cultural_promotion: "Persian Cultural Promotion"
  br_persia_defensive_military_posture: "Defensive Military Posture"
+ br_modifier_romaioi_roman_roads: "Romaíon Infrastructure"
 
  city_worlds_desire_state: "City of Worlds Desire"
  great_city_state: "Magnificent City"


### PR DESCRIPTION
This commit fixes the following error:

```
[techtreepanel.cpp:161]: Trying to add a tech
(roman_roads) to a category that does not exist in
the UI
```

This was solved by replacing the tech with a
modifier, which should also make the modifier more visible to the players.