### PR TITLE
fix: add missing localization keys

### DIFF
--- a/localization/english/br_names_l_english.yml
+++ b/localization/english/br_names_l_english.yml
@@ -180,6 +180,7 @@
  Tlahcoehua: "Tlahcoēhua"
  Tepin: "Tepin"
  Cihuaton: "Cihuāton"
+ Xōchitl: "Xōchitl"
 
  #Surnames
 
@@ -192,3 +193,16 @@
  Xocoyotzin: "Xocoyotzin"
  Tezozomoc: "Tezozomoc"
 
+ # Iberian
+ Jose: "José"
+ Joao: "João"
+
+ # German
+ Lugwig: "Lugwig"
+
+ # Polyneisan
+ Auli'i: "Auli'i"
+ Kina'u: "Kina'u"
+
+ # Patagonian
+ Victor_2: "Victor"


### PR DESCRIPTION
This commit solves the following error:

```
[culture_type.cpp:126]: Missing localization key
for name Jose in culture spanish
```
and similar errors.

Fixed by adding the missing keys to the
localization file.