### PR TITLE
feat: state-based silk road

### DIFF
--- a/common/history/countries/AGY - Aegypt.txt
+++ b/common/history/countries/AGY - Aegypt.txt
@@ -104,10 +104,7 @@
 			name = br_modifier_muslim_cultural_discrimination
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 		add_modifier = {
 			name = br_modifier_african_colony
 			months = -1
@@ -215,10 +212,7 @@
 			add_ruling_interest_group = yes
 		}
 
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 		#effect_starting_wealthy_merchants = yes
 
@@ -360,10 +354,7 @@
 			name = br_modifier_colonial_merchant_republic
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 		add_modifier = {
 			name = br_modifier_african_colony
 			months = -1

--- a/common/history/countries/ARA - Arabia.txt
+++ b/common/history/countries/ARA - Arabia.txt
@@ -48,10 +48,7 @@
 			name = romaioi_jihad
 			years = 75
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 		#change_infamy = 75
 
@@ -204,10 +201,7 @@
 			name = holy_warriors
 			years = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 		#In-Government
 
@@ -268,10 +262,7 @@
 			set_interest_group_name = ig_sunni_madrasahs 
 		}
 
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 	}
 
 	c:ABU = {
@@ -307,10 +298,7 @@
 			name = tribal_warriors
 			years = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 		#In-Government
 
@@ -358,10 +346,7 @@
 			name = tribal_warriors
 			years = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 		#In-Government
 
@@ -417,10 +402,7 @@
 			name = tribal_warriors
 			years = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 		add_modifier = {
 			name = br_modifier_african_colony
 			months = -1

--- a/common/history/countries/ARM - Armenia.txt
+++ b/common/history/countries/ARM - Armenia.txt
@@ -66,9 +66,6 @@
 			add_ideology = ideology_oriental_orthodox_patriarch
 		}
 
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 	}
 }

--- a/common/history/countries/ASY - Assyria.txt
+++ b/common/history/countries/ASY - Assyria.txt
@@ -40,10 +40,7 @@
 			name = persian_satraps
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 
 	}
@@ -116,10 +113,7 @@
 			name = tribal_warriors
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 	}
 
@@ -172,10 +166,7 @@
 			name = tribal_warriors
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 	}
 }

--- a/common/history/countries/GEO- Georgia.txt
+++ b/common/history/countries/GEO- Georgia.txt
@@ -65,9 +65,6 @@
 			add_ideology = ideology_russian_patriarch
 		}
 
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 	}
 }

--- a/common/history/countries/MAL - Mali.txt
+++ b/common/history/countries/MAL - Mali.txt
@@ -44,10 +44,7 @@
 			set_interest_group_name = ig_sunni_madrasahs
 		}
 
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 	}
 }

--- a/common/history/countries/MES - Mesopotamia.txt
+++ b/common/history/countries/MES - Mesopotamia.txt
@@ -58,10 +58,7 @@
 			name = subservient_patriarch
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 		ig:ig_devout = {
 			set_interest_group_name = ig_oriental_orthodox_church

--- a/common/history/countries/MUG - Mugalstan.txt
+++ b/common/history/countries/MUG - Mugalstan.txt
@@ -64,10 +64,7 @@
 			name = br_persia_defensive_military_posture
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 	}
 }

--- a/common/history/countries/NAF - Africa.txt
+++ b/common/history/countries/NAF - Africa.txt
@@ -117,10 +117,7 @@
 			name = br_modifier_muslim_cultural_discrimination
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 		add_modifier = {
 			name = br_modifier_african_colony
 			months = -1
@@ -257,10 +254,7 @@
 			name = br_modifier_muslim_cultural_discrimination
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 		add_modifier = {
 			name = br_modifier_african_colony
 			months = -1

--- a/common/history/countries/PAM - Persian Armenia.txt
+++ b/common/history/countries/PAM - Persian Armenia.txt
@@ -41,10 +41,7 @@
 			name = persian_satraps
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 	}
 }

--- a/common/history/countries/TAT - Tataria.txt
+++ b/common/history/countries/TAT - Tataria.txt
@@ -143,10 +143,7 @@
 			name = br_modifier_horde_army_prowess
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 	#	add_modifier = {
 	#		name = mongol_religious_tolerance
 	#		months = -1
@@ -187,10 +184,7 @@
 			name = tribal_warriors
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 	}
 	c:C03 = {
@@ -227,10 +221,7 @@
 			name = tribal_warriors
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 	}
 }

--- a/common/history/countries/afg - afghanistan.txt
+++ b/common/history/countries/afg - afghanistan.txt
@@ -25,9 +25,6 @@
 			set_interest_group_name = ig_sunni_madrasahs
 		}
 
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 	}
 }

--- a/common/history/countries/buk - bukkhara.txt
+++ b/common/history/countries/buk - bukkhara.txt
@@ -73,10 +73,7 @@
 			name = tribal_warriors
 			years = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 	}
 }

--- a/common/history/countries/chc - chechnya.txt
+++ b/common/history/countries/chc - chechnya.txt
@@ -48,9 +48,6 @@
 			name = tribal_warriors
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 	}
 }

--- a/common/history/countries/chi - china.txt
+++ b/common/history/countries/chi - china.txt
@@ -109,10 +109,7 @@
 			name = br_modifier_horde_army_prowess
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 
 
@@ -194,10 +191,7 @@
 			name = china_rampant_corruption
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 	}
 
@@ -277,10 +271,7 @@
 			name = china_rampant_corruption
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 	}
 	
@@ -700,10 +691,7 @@
 			name = china_rampant_corruption
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 	}
 
@@ -780,10 +768,7 @@
 			name = china_rampant_corruption
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 	}
 
@@ -861,10 +846,7 @@
 			name = china_rampant_corruption
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 	}
 

--- a/common/history/countries/khi - khiva.txt
+++ b/common/history/countries/khi - khiva.txt
@@ -74,10 +74,7 @@
 			name = tribal_warriors
 			years = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 	}
 }

--- a/common/history/countries/kon - kongo.txt
+++ b/common/history/countries/kon - kongo.txt
@@ -28,10 +28,7 @@
 			set_interest_group_name = ig_catholic_church
 		}
 
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 		add_modifier = {
 			name = br_modifier_african_colony
 			months = -1

--- a/common/history/countries/mjt - majerteen.txt
+++ b/common/history/countries/mjt - majerteen.txt
@@ -20,10 +20,7 @@
 			name = tribal_warriors
 			years = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 		ig:ig_devout = {
 			set_interest_group_name = ig_sunni_madrasahs

--- a/common/history/countries/per - persia.txt
+++ b/common/history/countries/per - persia.txt
@@ -92,10 +92,7 @@
 			name = br_persia_persian_cultural_promotion
 			months = -1
 		}
-		add_modifier = {
-			name = br_modifier_silk_road
-			years = -1
-		}
+
 
 	}
 }

--- a/common/history/global/03_br_silk_road.txt
+++ b/common/history/global/03_br_silk_road.txt
@@ -1,0 +1,68 @@
+﻿# Add silk road modifier to states
+GLOBAL = {
+	every_country = {
+		every_scope_state = {
+			limit = {
+				OR = {
+					# China
+					state_region = s:STATE_SUZHOU
+					state_region = s:STATE_NANJING
+					state_region = s:STATE_ZHEJIANG
+					state_region = s:STATE_SOUTHERN_ANHUI
+					state_region = s:STATE_HENAN
+					state_region = s:STATE_XIAN
+					state_region = s:STATE_NINGXIA
+					state_region = s:STATE_GANSU
+					state_region = s:STATE_QINGHAI
+
+					# Central Asia
+					state_region = s:STATE_TIANSHAN
+					state_region = s:STATE_KIRGHIZIA
+					state_region = s:STATE_UZBEKIA
+					state_region = s:STATE_TURKMENIA
+
+					# Persia
+					state_region = s:STATE_KHORASAN
+					state_region = s:STATE_IRAKAJEMI
+					state_region = s:STATE_LURISTAN
+					state_region = s:STATE_BAGHDAD
+
+					# Levant
+					state_region = s:STATE_DEIR_EZ_ZOR
+					state_region = s:STATE_ALEPPO
+					state_region = s:STATE_SYRIA
+					state_region = s:STATE_TRANSJORDAN
+					state_region = s:STATE_PALESTINE
+
+					# Egypt
+					state_region = s:STATE_SINAI
+					state_region = s:STATE_LOWER_EGYPT
+
+					# Anatolia
+					state_region = s:STATE_ADANA
+					state_region = s:STATE_ANKARA
+					state_region = s:STATE_KASTAMONU
+					state_region = s:STATE_HUDAVENDIGAR
+
+					# Balkans
+					state_region = s:STATE_EASTERN_THRACE
+				}
+			}
+			add_modifier = {
+				name = br_state_modifier_silk_road
+				years = -1
+			}
+		}
+	}
+	every_country = {
+		limit = {
+			any_scope_state = {
+				has_modifier = br_state_modifier_silk_road
+			}
+		}
+		add_modifier = {
+			name = br_modifier_silk_road
+			months = -1
+		}
+	}
+}

--- a/common/modifiers/br_trade_modifiers.txt
+++ b/common/modifiers/br_trade_modifiers.txt
@@ -1,10 +1,15 @@
 ﻿br_modifier_silk_road = {
 	icon = gfx/interface/icons/timed_modifier_icons/modifier_coins_positive.dds
 
-	state_infrastructure_from_population_add = 1
-	state_infrastructure_from_population_max_add = 10
 	country_trade_route_cost_mult = -0.25
 	country_trade_route_competitiveness_mult = 0.25
 	market_land_trade_capacity_add = 250
+}
+
+br_state_modifier_silk_road = {
+	icon = gfx/interface/icons/timed_modifier_icons/modifier_coins_positive.dds
+
+	state_infrastructure_from_population_add = 1
+	state_infrastructure_from_population_max_add = 10
 	state_market_access_price_impact = 0.05
 }

--- a/common/on_actions/br_silk_road_on_actions.txt
+++ b/common/on_actions/br_silk_road_on_actions.txt
@@ -1,0 +1,30 @@
+﻿on_monthly_pulse_country = {
+	on_actions = {
+		br_silk_road_remove_country_modifier
+		br_silk_road_add_country_modifier
+	}
+}
+
+br_silk_road_remove_country_modifier = {
+	trigger = {
+		has_modifier = br_modifier_silk_road
+	}
+	effect = {
+		trigger_event = {
+			id = br_namespace_silk_road.1
+		}
+	}
+}
+
+br_silk_road_add_country_modifier = {
+	trigger = {
+		NOT = {
+			has_modifier = br_modifier_silk_road
+		}
+	}
+	effect = {
+		trigger_event = {
+			id = br_namespace_silk_road.2
+		}
+	}
+}

--- a/events/br_event_silk_road.txt
+++ b/events/br_event_silk_road.txt
@@ -1,0 +1,33 @@
+﻿namespace = br_namespace_silk_road
+
+br_namespace_silk_road.1 = {
+	type = country_event
+	hidden = yes
+	immediate = {
+		if = {
+			limit = {
+				any_scope_state = {
+					has_modifier = br_state_modifier_silk_road
+				}
+			}
+		}
+		else = {
+			remove_modifier = br_modifier_silk_road
+		}
+	}
+}
+
+br_namespace_silk_road.2 = {
+	type = country_event
+	hidden = yes
+	immediate = {
+		if = {
+			limit = {
+				any_scope_state = {
+					has_modifier = br_state_modifier_silk_road
+				}
+			}
+			add_modifier = br_modifier_silk_road
+		}
+	}
+}

--- a/localization/english/br_modifiers_l_english.yml
+++ b/localization/english/br_modifiers_l_english.yml
@@ -100,8 +100,11 @@
  br_modifier_italy_colonial_dividends: "Colonial Dividends"
  br_modifier_italy_gunboat_trade_diplomacy: "Gunboat Diplomacy"
 
+ # State modifiers
  city_worlds_desire_state: "City of Worlds Desire"
  great_city_state: "Magnificent City"
+ br_state_modifier_silk_road: "Silk Road"
+
  merchant_state: "Grand Port"
  roman_senate: "Synkletos"
  romaioi_corrupt_pronoia: "Thematic deterioration"


### PR DESCRIPTION
# Motivation

The current silk road system does not really have
any connection with any states, which makes it a
little bit uninteresting.

This commit now binds the silk road to states.

# Changes

Countries at game start now will get the
country-wide modifier if they control one (or part of one) state that has a silk road modifier.

The silk road states were chosen from the
following map:
https://en.wikipedia.org/wiki/Silk_Road#/media/File:SeidenstrasseGMT.JPG

The modifier has also been split between the
state-based one and the country-wide one.

Every month countries that do not control at least one part of a state with the silk road modifier
will lose the country-wide modifier.

Every month countries that control at least one
part of a state with the silk road modifier will
gain the country-wide modifier if they do not have it already.