### PR TITLE
fix: delete inappropriate buildings

### DIFF
--- a/common/history/buildings/17_br_east_asia_buildings.txt
+++ b/common/history/buildings/17_br_east_asia_buildings.txt
@@ -176,12 +176,6 @@
 	s:STATE_SHAOZHOU={
 		region_state:YUE={
 			create_building={
-				building="building_artillery_foundries"
-				level=1
-				reserves=1
-				activate_production_methods={ "pm_cannons" "pm_merchant_guilds_building_artillery_foundries" }
-			}
-			create_building={
 				building="building_government_administration"
 				level=5
 				reserves=1
@@ -642,12 +636,6 @@
 				level=2
 				reserves=1
 				activate_production_methods={ "pm_basic_shipbuilding" "pm_merchant_guilds_building_shipyards" }
-			}
-			create_building={
-				building="building_naval_base"
-				level=15
-				reserves=1
-				activate_production_methods={ "pm_no_naval_theory" }
 			}
 			create_building={
 				building="building_port"


### PR DESCRIPTION
This commit fixes the following error:

```
[jomini_script_system.cpp:262]: Script system
error! Error: create_building effect [ 
simple_box! tooltippable_name 
tooltip:dw_3890882381,CAEAAA==,DATA_COUNTRY_NAME_TOOLTIP,CountryTooltip 
YUE264!flag_overlay! Yue!! has invented 
tooltippable_name 
tooltip:dw_2373183554,oH+bvScFAAA=,DATA_TECHNOLOGY_NAME_TOOLTIP,TechnologyTooltip
Gunsmithing!! ] Script location: file:
common/history/buildings/17_br_east_asia_buildings.txt
line: 178
```

This is done by deleting the buildings in
question.