### PR TITLE
fix: add missing localization

### DIFF
--- a/localization/english/br_addon_content_l_english.yml
+++ b/localization/english/br_addon_content_l_english.yml
@@ -3,6 +3,8 @@
  FX_ask_subject_to_fight: "Command a Subject to Attack this Nation"
  FX_ask_subject_to_fight_action_name: "Subject Attack"
  FX_ask_subject_to_fight_desc: "Command a Subject to Attack this Nation"
+ FX_ask_subject_to_fight_action_notification_name: "Subject Attack Command"
+ FX_ask_subject_to_fight_action_notification_desc: "[INITIATOR_COUNTRY.GetName] commands us to attack target [TARGET_COUNTRY.GetName]"
  subject_fight_for_lord: "Command Subjects to Attack"
  FX_subject_fight.1.t: "Select which Subject will Attack the Target"
  FX_subject_fight.1.d: "Select which subject will Attack the Target"


### PR DESCRIPTION
This commit solves the following error:

```
[diplomatic_action_type.cpp:1536]: Missing
localization key for diplomatic action! Key:
FX_ask_subject_to_fight_action_notification_name
```