### PR TITLE
feat: give unique tech for frontier colonization

### DIFF
--- a/common/laws/00_colonial_affairs.txt
+++ b/common/laws/00_colonial_affairs.txt
@@ -59,7 +59,7 @@ law_frontier_colonization = {
 	progressiveness = 25
 
 	unlocking_technologies = {
-		colonization
+		frontier_expansion
 	}
 
 	limited_to_frontier_colonization = yes

--- a/common/technology/technologies/br_society_1736-1836.txt
+++ b/common/technology/technologies/br_society_1736-1836.txt
@@ -105,6 +105,22 @@ tech_agrarianism = {
 	}
 }
 
+frontier_expansion = {
+	# Earliest colonization tech
+	# https://en.wikipedia.org/wiki/Frontier#History
+	era = era_1
+	texture = "gfx/interface/icons/invention_icons/colonization.dds"
+	category = society
+
+	unlocking_technologies = {
+		tech_agrarianism
+	}
+
+	ai_weight = {
+		value = 2
+	}
+}
+
 smithian_economics = {
 	# Tech that tries to bridges the mercantilist past and free trade future
 	# https://en.wikipedia.org/wiki/Classical_economics#

--- a/common/technology/technologies/br_society_1836-1936.txt
+++ b/common/technology/technologies/br_society_1836-1936.txt
@@ -270,7 +270,7 @@ colonization = {
 	}
 
 	unlocking_technologies = {
-		international_relations
+		frontier_expansion
 	}
 
 	ai_weight = {

--- a/localization/english/br_technology_l_english.yml
+++ b/localization/english/br_technology_l_english.yml
@@ -36,6 +36,8 @@
  tech_mercantilism_desc: "An economic theory that emphasizes the importance of accumulating wealth through trade and the establishment of colonies."
  tech_agrarianism: "Agrarianism"
  tech_agrarianism_desc: "A political and social philosophy that emphasizes the importance of agriculture and rural life."
+ frontier_expansion: "Frontier Expansion"
+ frontier_expansion_desc: "The process of moving the boundaries of a country or territory into new, unclaimed land. It was a common feature of European colonization in the Americas."
  smithian_economics: "Smithian Economics"
  smithian_economics_desc: "An economic theory that was developed by Adam Smith and emphasizes the importance of free markets, competition, and self-interest."
  fiat_currency: "Fiat Currency"


### PR DESCRIPTION
# Motivation

All of the colonization techs should not be
available all at once. This way a players must be
more strategic in how they want to approach
colonization.

# Changes

- Added a new tech called `Frontier Expansion`
- `frontier_colonization` tech now requires "Frontier Expansion" tech