### PR TITLE
fix: avoid reusing localization keys

### DIFF
--- a/common/buildings/br_agro.txt
+++ b/common/buildings/br_agro.txt
@@ -152,7 +152,7 @@ building_vineyard_plantation = {
 	required_construction = construction_cost_low
 
 	unlocking_technologies = {
-		four_field_crop_rotation
+		br_tech_four_field_crop_rotation
 	}
 
 	city_type = farm

--- a/common/buildings/br_plantations.txt
+++ b/common/buildings/br_plantations.txt
@@ -6,7 +6,7 @@ building_coffee_plantation = {
 	required_construction = construction_cost_low
 
 	unlocking_technologies = {
-		four_field_crop_rotation
+		br_tech_four_field_crop_rotation
 	}
 
 	city_type = farm
@@ -44,7 +44,7 @@ building_dye_plantation = {
 	required_construction = construction_cost_low
 
 	unlocking_technologies = {
-		four_field_crop_rotation
+		br_tech_four_field_crop_rotation
 	}
 
 	city_type = farm
@@ -95,7 +95,7 @@ building_tea_plantation = {
 	required_construction = construction_cost_low
 
 	unlocking_technologies = {
-		four_field_crop_rotation
+		br_tech_four_field_crop_rotation
 	}
 
 	city_type = farm
@@ -133,7 +133,7 @@ building_sugar_plantation = {
 	required_construction = construction_cost_low
 
 	unlocking_technologies = {
-		four_field_crop_rotation
+		br_tech_four_field_crop_rotation
 	}
 
 	city_type = farm
@@ -171,7 +171,7 @@ building_silk_plantation = {
 	required_construction = construction_cost_low
 
 	unlocking_technologies = {
-		four_field_crop_rotation
+		br_tech_four_field_crop_rotation
 	}
 
 	city_type = farm
@@ -191,7 +191,7 @@ building_spices_plantation = {
 	required_construction = construction_cost_low
 
 	unlocking_technologies = {
-		four_field_crop_rotation
+		br_tech_four_field_crop_rotation
 	}
 
 	city_type = farm

--- a/common/laws/br_distribution_of_power.txt
+++ b/common/laws/br_distribution_of_power.txt
@@ -244,7 +244,7 @@ law_wealth_voting = {
 	progressiveness = 0
 
 	unlocking_technologies = {
-		separation_of_powers
+		br_tech_separation_of_powers
 	}
 
 	disallowing_laws = {

--- a/common/laws/br_governance_principles.txt
+++ b/common/laws/br_governance_principles.txt
@@ -6,7 +6,7 @@
 	progressiveness = 100
 	
 	unlocking_technologies = {
-		separation_of_powers
+		br_tech_separation_of_powers
 	}
 	
 	modifier = {

--- a/common/scripted_effects/00_starting_inventions.txt
+++ b/common/scripted_effects/00_starting_inventions.txt
@@ -60,7 +60,7 @@ effect_starting_technology_tier_3_tech = {
 	add_technology_researched = urbanization
 	add_technology_researched = rationalism
 	add_technology_researched = tech_bureaucracy
-	add_technology_researched = separation_of_powers
+	add_technology_researched = br_tech_separation_of_powers
 	add_technology_researched = democracy
 	add_technology_researched = romanticism
 	add_technology_researched = academia
@@ -88,7 +88,7 @@ effect_starting_technology_tier_4_tech = {
 	
 
 	# Cultural
-	add_technology_researched = separation_of_powers
+	add_technology_researched = br_tech_separation_of_powers
 	add_technology_researched = urbanization
 	add_technology_researched = tech_bureaucracy
 	add_technology_researched = international_relations
@@ -101,7 +101,7 @@ effect_starting_technology_tier_5_tech = {
 	add_technology_researched = enclosure
 	add_technology_researched = seed_drill
 	add_technology_researched = rotherham_plough
-	add_technology_researched = four_field_crop_rotation
+	add_technology_researched = br_tech_four_field_crop_rotation
 	add_technology_researched = artisan_manufacturing
 	add_technology_researched = surface_mining
 	add_technology_researched = new_world_crops
@@ -133,7 +133,7 @@ effect_starting_technology_tier_6_tech = {
     # Economic
 	add_technology_researched = enclosure
 	add_technology_researched = new_world_crops
-	add_technology_researched = four_field_crop_rotation
+	add_technology_researched = br_tech_four_field_crop_rotation
 
 	# Military
 	add_technology_researched = military_levy
@@ -151,7 +151,7 @@ effect_starting_technology_tier_7_tech = {
 	# Economic
 	add_technology_researched = enclosure
 	add_technology_researched = new_world_crops 
-	add_technology_researched = four_field_crop_rotation
+	add_technology_researched = br_tech_four_field_crop_rotation
 
 	# Military
 	add_technology_researched = gunsmithing

--- a/common/technology/technologies/br_production_1736-1836.txt
+++ b/common/technology/technologies/br_production_1736-1836.txt
@@ -56,7 +56,7 @@ seed_drill = {
 	}
 
 	unlocking_technologies = {
-		four_field_crop_rotation
+		br_tech_four_field_crop_rotation
 	}
 
 	ai_weight = {
@@ -86,7 +86,7 @@ rotherham_plough = {
 	}
 }
 
-four_field_crop_rotation = {
+br_tech_four_field_crop_rotation = {
 	# Placeholder for even older agriculture techs
 	era = era_1
 	texture = "gfx/interface/icons/invention_icons/enclosure.dds"

--- a/common/technology/technologies/br_society_1736-1836.txt
+++ b/common/technology/technologies/br_society_1736-1836.txt
@@ -258,7 +258,7 @@ rights_of_man = {
 	}
 }
 
-separation_of_powers = {
+br_tech_separation_of_powers = {
 	# If there are any vanilla updates to separation of powers, this tech should be updated.
 	# Should probably be a more recent tech
 	# https://en.wikipedia.org/wiki/Separation_of_powers#History

--- a/common/technology/technologies/br_society_1836-1936.txt
+++ b/common/technology/technologies/br_society_1836-1936.txt
@@ -137,7 +137,7 @@ democracy = {
 
 	unlocking_technologies = {
 		rationalism
-		separation_of_powers
+		br_tech_separation_of_powers
 	}
 
 	ai_weight = {

--- a/localization/english/br_technology_l_english.yml
+++ b/localization/english/br_technology_l_english.yml
@@ -1,7 +1,7 @@
 ﻿l_english:
  # Agriculture
- four_field_crop_rotation: "Four-Field Crop Rotation"
- four_field_crop_rotation_desc: "A system of crop rotation that allows for the cultivation of four different crops in four different fields, which helps to maintain soil fertility."
+ br_tech_four_field_crop_rotation: "Four-Field Crop Rotation"
+ br_tech_four_field_crop_rotation_desc: "A system of crop rotation that allows for the cultivation of four different crops in four different fields, which helps to maintain soil fertility."
  rotherham_plough: "Rotherham Plough"
  rotherham_plough_desc: "A type of plough that was used in the 18th century and was designed to be pulled by horses. It was a significant improvement over the traditional plough."
  new_world_crops: "New World Crops"
@@ -58,8 +58,8 @@
  rights_of_man_desc: "The idea that all human beings are entitled to certain rights and freedoms, such as liberty, equality, and justice."
  divine_right: "Divine Right"
  divine_right_desc: "The belief that a monarch's authority to rule comes directly from God."
- separation_of_powers: "Separation of Powers"
- separation_of_powers_desc: "The idea of distinct branches of government with different roles which oversee one another to prevent corruption and abuse has become vastly more popular since the relative success of the 'great American experiment', with her Constitution splitting the government into executive, legislative and judicial branches."
+ br_tech_separation_of_powers: "Separation of Powers"
+ br_tech_separation_of_powers_desc: "The idea of distinct branches of government with different roles which oversee one another to prevent corruption and abuse has become vastly more popular since the relative success of the 'great American experiment', with her Constitution splitting the government into executive, legislative and judicial branches."
  early_modern_universities: "Early Modern Universities"
  early_modern_universities_desc: "Institutions of higher learning that emerged in Europe during the late Middle Ages and early modern period. They were centers of scholarship and research."
  natural_history: "Natural History"


### PR DESCRIPTION
This commit solves the following error:

```
[pdx_localize.cpp:197]: Duplicate localization
key. Key 'separation_of_powers' is defined in both
'localization/english/br_technology_l_english.yml'
and
'localization/english/inventions_l_english.yml'.
```

The fix is to simply rename the conflicting keys.