### PR TITLE
fix: too many sashes

### DIFF
--- a/gfx/portraits/portrait_modifiers/romaioi_clothes.txt
+++ b/gfx/portraits/portrait_modifiers/romaioi_clothes.txt
@@ -1350,7 +1350,7 @@ com_clothes = {
             }
         }
         weight = {
-            base = 1
+            base = 0
         }
     }
 


### PR DESCRIPTION
This commit solves the issue introduced by commit
593001c07023b954dbe57e437d838a933f38ccef, by
disabling the sash logic.